### PR TITLE
Python 2 fixes + insert size distribution

### DIFF
--- a/iss/app.py
+++ b/iss/app.py
@@ -75,7 +75,12 @@ def generate_reads(args):
                 logger.error(
                     '--ncbi and --n_genomes of unequal lengths. Aborting')
                 sys.exit(1)
-            for g, n in zip(*args.ncbi, *args.n_genomes):
+            # for g, n in zip(*args.ncbi, *args.n_genomes):  # this is py3 only
+            # py2 compatibilty workaround
+            # TODO remove when we drop python2
+            args.ncbi = [x for y in args.ncbi for x in y]
+            args.n_genomes = [x for y in args.n_genomes for x in y]
+            for g, n in zip(args.ncbi, args.n_genomes):
                 genomes = download.ncbi(g, n)
                 total_genomes.extend(genomes)
             genome_file = download.to_fasta(total_genomes, args.output)
@@ -394,4 +399,4 @@ def main():
         logger = logging.getLogger(__name__)
         logger.debug(e)
         parser.print_help()
-        # raise  # extra traceback to uncomment if all hell breaks lose
+        raise  # extra traceback to uncomment if all hell breaks lose

--- a/iss/app.py
+++ b/iss/app.py
@@ -399,4 +399,4 @@ def main():
         logger = logging.getLogger(__name__)
         logger.debug(e)
         parser.print_help()
-        raise  # extra traceback to uncomment if all hell breaks lose
+        # raise  # extra traceback to uncomment if all hell breaks lose

--- a/iss/download.py
+++ b/iss/download.py
@@ -4,7 +4,7 @@
 from Bio import SeqIO
 from Bio import Entrez
 
-import http
+import http.client
 import random
 import logging
 

--- a/iss/error_models/__init__.py
+++ b/iss/error_models/__init__.py
@@ -178,7 +178,7 @@ class ErrorModel(object):
                 for nucl_to_insert, prob in insertions[position].items():
                     if random.random() < prob:
                         # we want to insert after the base read
-                        mutable_seq.insert(position + 1, nucl_to_insert)
+                        mutable_seq.insert(position + 1, str(nucl_to_insert))
                 if random.random() < deletions[position][mutable_seq[nucl]]:
                     mutable_seq.pop(position)
                 position += 1

--- a/iss/generator.py
+++ b/iss/generator.py
@@ -91,8 +91,14 @@ def simulate_read(record, ErrorModel, i):
     insert_size = ErrorModel.random_insert_size()
     # generate the forward read
     try:  # a ref sequence has to be longer than 2 * read_length + i_size
+        assert read_length <= len(record.seq)
         forward_start = random.randrange(
             0, len(record.seq) - (2 * read_length + insert_size))
+    except AssertionError as e:
+        logger.error(
+            '%s shorter than read length for this ErrorModel:%s'
+            % (e, record.id))
+        sys.exit(1)
     except ValueError as e:
         logger.debug(
             '%s shorter than template length for this ErrorModel:%s'

--- a/iss/test/test_generator.py
+++ b/iss/test/test_generator.py
@@ -53,7 +53,20 @@ def test_simulate_and_save():
     generator.reads(ref_genome, err_mod, 1000, 0, 'data/.test', True)
 
 
-@raises(ValueError)
+@with_setup(setup_function, teardown_function)
+def test_simulate_And_save_short():
+    err_mod = basic.BasicErrorModel()
+    ref_genome = SeqRecord(
+        Seq(str('AACCC' * 100),
+            IUPAC.unambiguous_dna
+            ),
+        id='my_genome',
+        description='test genome'
+        )
+    generator.reads(ref_genome, err_mod, 1000, 0, 'data/.test', True)
+
+
+@raises(SystemExit)
 def test_small_input():
     err_mod = kde.KDErrorModel('data/ecoli.npz')
     ref_genome = SeqRecord(
@@ -98,3 +111,20 @@ def test_kde():
         read_tuple = generator.simulate_read(ref_genome, err_mod, 1)
         big_read = ''.join(str(read_tuple[0].seq) + str(read_tuple[1].seq))
         assert big_read[:15] == 'CCGTTTCAACCCGTT'
+
+
+def test_kde_short():
+        if sys.version_info > (3,):
+            random.seed(42)
+            np.random.seed(42)
+            err_mod = kde.KDErrorModel('data/ecoli.npz')
+            ref_genome = SeqRecord(
+                Seq(str('AAACC' * 100),
+                    IUPAC.unambiguous_dna
+                    ),
+                id='my_genome',
+                description='test genome'
+                )
+            read_tuple = generator.simulate_read(ref_genome, err_mod, 1)
+            big_read = ''.join(str(read_tuple[0].seq) + str(read_tuple[1].seq))
+            assert big_read == 'ACCAAACCAAACCAAACCAAGGTTTGGTTTGGTTTGGTGT'


### PR DESCRIPTION
This PR addresses the bugs from #45 (and more):

Python2 related:
* `zip(*args.ncbi, *args.n_genomes)` not supported. Changed syntax.
* changed `import http`to `import http.client` to catch the incomplete download/N exceptions
* insertions are `str` and not unicode anymore

Not python2 related:
* iss does not skip a genome if its length is shorter than the random insert size drawn from the model. Produces a random insert size within acceptable limits instead.