### PR TITLE
follow the paired reads name convention, /1 and /2 at the end

### DIFF
--- a/iss/generator.py
+++ b/iss/generator.py
@@ -114,7 +114,7 @@ def simulate_read(record, ErrorModel, i):
         Seq(str(sequence[forward_start:forward_end]),
             IUPAC.unambiguous_dna
             ),
-        id='%s_%s_1' % (header, i),
+        id='%s_%s/1' % (header, i),
         description=''
     )
     # add the indels, the qual scores and modify the record accordingly
@@ -139,7 +139,7 @@ def simulate_read(record, ErrorModel, i):
         Seq(rev_comp(str(sequence[reverse_start:reverse_end])),
             IUPAC.unambiguous_dna
             ),
-        id='%s_%s_2' % (header, i),
+        id='%s_%s/2' % (header, i),
         description=''
     )
     # add the indels, the qual scores and modify the record accordingly


### PR DESCRIPTION
I have use [ncbi-genome-download](https://github.com/kblin/ncbi-genome-download) to download some bacteria reference genome,
and merge them to one single file, then use [InSilicoSeq](https://github.com/HadrienG/InSilicoSeq) to generate metagenomics reads.
But when I use bwa mapping these reads to assembly genome, bwa told me, 
**paired reads have different name**.
So, I change the code. May be helpful.
Thank HadrienG!