### PR TITLE
Fix out-of-bounds error

### DIFF
--- a/iss/error_models/__init__.py
+++ b/iss/error_models/__init__.py
@@ -132,7 +132,10 @@ class ErrorModel(object):
             to_add = self.read_length - len(mut_seq)
             if orientation == 'forward':
                 for i in range(to_add):
-                    nucl_to_add = str(full_sequence[read_end + i])
+                    if read_end + i > len(full_sequence):
+                        nucl_to_add = 'A'
+                    else:
+                        nucl_to_add = str(full_sequence[read_end + i])
                     mut_seq.append(nucl_to_add)
             elif orientation == 'reverse':
                 for i in range(to_add):


### PR DESCRIPTION
This pull request provides a simple solution to the problem described in #96. If the computed index is greater than the length of the sequence, append `A`. Otherwise, append the requested nucleotide.

I'm assuming this problem doesn't occur much with whole genome sequences, since it's very rare for a read both to have an indel and line up right at the end of the chromosome. However, when sequencing short amplicons in draft mode this case occurred with high frequency.

There are probably more elegant solutions to this problem. One could:
- draw a random base instead of `A`
- draw a base from some distribution of nucleotide composition
- append Illumina adapters or other technical sequences to the end of the genomic sequence

But for now, this is a simple solution that allows InSilicoSeq to run without barfing on amplicon sequences.