### PR TITLE
Write reads to disk immediately instead of caching them in RAM

### DIFF
--- a/iss/generator.py
+++ b/iss/generator.py
@@ -50,7 +50,17 @@ def reads(record, ErrorModel, n_pairs, cpu_number, output, seed,
     logger.debug(
         'Cpu #%s: Generating %s read pairs'
         % (cpu_number, n_pairs))
-    read_tuple_list = []
+
+    temp_file_name = output + '.iss.tmp.%s.%s' % (record.id, cpu_number)
+    to_fastq(
+        reads_generator(n_pairs, record, ErrorModel, cpu_number, gc_bias),
+        temp_file_name
+    )
+
+    return temp_file_name
+
+
+def reads_generator(n_pairs, record, ErrorModel, cpu_number, gc_bias):
     i = 0
     while i < n_pairs:
         # try:
@@ -75,18 +85,13 @@ def reads(record, ErrorModel, n_pairs, cpu_number, output, seed,
                     read_tuple_list.append((forward, reverse))
                     i += 1
                 elif np.random.rand() < 0.90:
-                    read_tuple_list.append((forward, reverse))
+                    yield (forward, reverse)
                     i += 1
                 else:
                     continue
             else:
-                read_tuple_list.append((forward, reverse))
+                yield (forward, reverse)
                 i += 1
-
-    temp_file_name = output + '.iss.tmp.%s.%s' % (record.id, cpu_number)
-    to_fastq(read_tuple_list, temp_file_name)
-
-    return temp_file_name
 
 
 def simulate_read(record, ErrorModel, i, cpu_number):


### PR DESCRIPTION
First of all, thank you for making ISS. I find it very fast and easy to use, especially because it ships with error models.

When trying it out I noted that it uses a lot of RAM, which seemed odd for a read simulator, especially since it slowly eats RAM over time. However I think I found the reason and a fix for that.

When generating reads, ISS first stores all reads in a python list in RAM. Only after generating all reads, it writes them to disk.

However, it would be much more memory efficient to write them to disk immediately after generation. So this is what I did. I moved the read generation code into a generator function `reads_generator` which I pass to `to_fastq`.

As a result, the memory usage is now small and stays constant during generation.