### PR TITLE
Amplicon sequence generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.bam
 *.bam.bai
 *.bt2
+*.npz
 test_runs/
 
 # Byte-compiled / optimized / DLL files
@@ -11,6 +12,7 @@ __pycache__/
 
 # Distribution / packaging
 *.egg-info/
+.eggs/
 dist/
 build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.eggs/
 
 # Unit test / coverage reports
 .cache
@@ -40,3 +41,8 @@ venv_iss/
 
 # editor configs
 .vscode/
+
+# test
+stuff/
+venv
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ __pycache__/
 *.egg-info/
 dist/
 build/
-.eggs/
 
 # Unit test / coverage reports
 .cache
@@ -41,8 +40,3 @@ venv_iss/
 
 # editor configs
 .vscode/
-
-# test
-stuff/
-venv
-.envrc

--- a/iss/app.py
+++ b/iss/app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from iss import bam
 from iss import util
 from iss import download
 from iss import abundance
@@ -9,12 +8,11 @@ from iss import generator
 from iss.version import __version__
 
 from Bio import SeqIO
-from joblib import Parallel, delayed, load, dump
+from joblib import Parallel, delayed
 
 import gc
 import os
 import sys
-import pickle
 import random
 import logging
 import argparse

--- a/iss/app.py
+++ b/iss/app.py
@@ -559,7 +559,7 @@ def main():
         '--sequence_type',
         '-t',
         choices=['metagenomics', 'amplicon'],
-        default='amplicon',
+        default='metagenomics',
         required=True,
         help='Type of sequencing. Can be metagenomics or amplicon (default: %(default)s).'
     )

--- a/iss/app.py
+++ b/iss/app.py
@@ -559,8 +559,9 @@ def main():
         '--sequence_type',
         '-t',
         choices=['metagenomics', 'amplicon'],
+        default='amplicon',
         required=True,
-        help='Type of sequencing. Can be metagenomics or amplicon.'
+        help='Type of sequencing. Can be metagenomics or amplicon (default: %(default)s).'
     )
     parser_gen._optionals.title = 'arguments'
     parser_gen.set_defaults(func=generate_reads)

--- a/iss/app.py
+++ b/iss/app.py
@@ -361,7 +361,11 @@ def model_from_bam(args):
         sys.exit(1)
     else:
         logger.info('Using KDE ErrorModel')
-        bam.to_model(args.bam, args.output)
+        if 40 % args.n_bins != 0:
+            logger.error(f'Not able to create {args.n_bins} equal bins for quality range [0..40]')
+            sys.exit(1)
+        
+        bam.to_model(args.bam, args.output, args.min_read_length, args.n_bins, args.sample_size)
         logger.info('Model generation complete')
 
 
@@ -594,6 +598,31 @@ def main():
         help='Output file path and prefix (Required)',
         required=True
     )
+    parser_mod.add_argument(
+        '--min_read_length',
+        '-l',
+        metavar='<len>',
+        type=int,
+        default=0,
+        help='Minimum read length for using read in model (default: %(default)s).'
+    )
+    parser_mod.add_argument(
+        '--n_bins',
+        '-n',
+        metavar='<bins>',
+        default=4,
+        type=int,
+        help='Number of quality bins to use (default: %(default)s).'
+    )
+    parser_mod.add_argument(
+        '--sample_size',
+        '-s',
+        metavar='<samples>',
+        default=1e6,
+        type=lambda x: int(float(x)),
+        help='Number of read to sample from the bamfile (default: %(default)s).'
+    )
+    
     parser_mod._optionals.title = 'arguments'
     parser_mod.set_defaults(func=model_from_bam)
     args = parser.parse_args()

--- a/iss/app.py
+++ b/iss/app.py
@@ -361,11 +361,7 @@ def model_from_bam(args):
         sys.exit(1)
     else:
         logger.info('Using KDE ErrorModel')
-        if 40 % args.n_bins != 0:
-            logger.error(f'Not able to create {args.n_bins} equal bins for quality range [0..40]')
-            sys.exit(1)
-        
-        bam.to_model(args.bam, args.output, args.min_read_length, args.n_bins, args.sample_size)
+        bam.to_model(args.bam, args.output)
         logger.info('Model generation complete')
 
 
@@ -598,31 +594,6 @@ def main():
         help='Output file path and prefix (Required)',
         required=True
     )
-    parser_mod.add_argument(
-        '--min_read_length',
-        '-l',
-        metavar='<len>',
-        type=int,
-        default=0,
-        help='Minimum read length for using read in model (default: %(default)s).'
-    )
-    parser_mod.add_argument(
-        '--n_bins',
-        '-n',
-        metavar='<bins>',
-        default=4,
-        type=int,
-        help='Number of quality bins to use (default: %(default)s).'
-    )
-    parser_mod.add_argument(
-        '--sample_size',
-        '-s',
-        metavar='<samples>',
-        default=1e6,
-        type=lambda x: int(float(x)),
-        help='Number of read to sample from the bamfile (default: %(default)s).'
-    )
-    
     parser_mod._optionals.title = 'arguments'
     parser_mod.set_defaults(func=model_from_bam)
     args = parser.parse_args()

--- a/iss/bam.py
+++ b/iss/bam.py
@@ -23,12 +23,10 @@ def read_bam(bam_file, n_reads=1000000):
     logger = logging.getLogger(__name__)
 
     try:
-        logger.info('Reading bam file: %s' % bam_file)
         lines = pysam.idxstats(bam_file).splitlines()
         total_records = sum([int(l.split("\t")[2])
                             for l in lines if not l.startswith("#")])
         # total_records = sum(1 for _ in bam.fetch() if not _.is_unmapped)
-        logger.debug(f"{total_records} reads available for sampling")
         random_fraction = n_reads / total_records
         bam = pysam.AlignmentFile(bam_file, 'rb')  # reopen the file
 
@@ -37,7 +35,7 @@ def read_bam(bam_file, n_reads=1000000):
         logger.error('Failed to read bam file: %s' % e)
         sys.exit(1)
     else:
-        logger.info('Iterating mapped reads:')
+        logger.info('Reading bam file: %s' % bam_file)
         c = 0
         with bam:
             for read in bam.fetch():
@@ -51,7 +49,6 @@ def read_bam(bam_file, n_reads=1000000):
                     yield read
                 elif c >= n_reads:
                     break
-            bam = pysam.AlignmentFile(bam_file, 'rb', threads=2)  # reopen the file
 
 
 def write_to_file(model, read_length, mean_f, mean_r, hist_f, hist_r,
@@ -107,7 +104,7 @@ def write_to_file(model, read_length, mean_f, mean_r, hist_f, hist_r,
         sys.exit(1)
 
 
-def to_model(bam_path, output, min_read_length, n_bins, sample_size):
+def to_model(bam_path, output):
     """from a bam file, write all variables needed for modelling reads in
     a .npz model file
 
@@ -119,7 +116,6 @@ def to_model(bam_path, output, min_read_length, n_bins, sample_size):
         output (string): prefix of the output file
     """
     logger = logging.getLogger(__name__)
-    min_bin_size = 5
 
     insert_size_dist = []
     qualities_forward = []
@@ -130,9 +126,7 @@ def to_model(bam_path, output, min_read_length, n_bins, sample_size):
     indel_matrix_r = np.zeros([301, 9])
 
     # read the bam file and extract info needed for modelling
-    for read in read_bam(bam_path, sample_size):
-        if len(read.seq) < min_read_length:
-            continue
+    for read in read_bam(bam_path):
         # get insert size distribution
         if read.is_proper_pair:
             template_length = abs(read.template_length)
@@ -142,6 +136,7 @@ def to_model(bam_path, output, min_read_length, n_bins, sample_size):
         # get qualities
         if read.is_read1:
             # get mean quality too
+            quality_means = []
             read_quality = read.query_qualities
             mean_quality = np.mean(read_quality)
             if read.is_reverse:
@@ -153,6 +148,7 @@ def to_model(bam_path, output, min_read_length, n_bins, sample_size):
             # qualities_forward.append(read.query_qualities)
         elif read.is_read2:
             # get mean quality too
+            quality_means = []
             read_quality = read.query_qualities
             mean_quality = np.mean(read_quality)
             if read.is_reverse:
@@ -183,27 +179,20 @@ def to_model(bam_path, output, min_read_length, n_bins, sample_size):
                 elif read.is_read2:
                     indel_matrix_r[pos, indel] += 1
 
-    logger.debug(f"forwared qs: {len(qualities_forward)}, reverse qs: {len(qualities_reverse)}")
-    logger.debug(f"insert sizes: {len(insert_size_dist)}, {min(insert_size_dist)} - {max(insert_size_dist)}")
     logger.info('Calculating insert size distribution')
-
+    # insert_size = int(np.mean(insert_size_dist))
     hist_insert_size = modeller.insert_size(insert_size_dist)
 
     logger.info('Calculating mean and base quality distribution')
-    # Divides qualities into bins, bins can be empty
-    quality_bins_f = modeller.divide_qualities_into_bins(qualities_forward, n_bins)
-    quality_bins_f = [bin if len(bin) > min_bin_size else [] for bin in quality_bins_f]
-    quality_bins_r = modeller.divide_qualities_into_bins(qualities_reverse, n_bins)
-    quality_bins_r = [bin if len(bin) > min_bin_size else [] for bin in quality_bins_r]
-    logger.debug(f"Forward bin sizes {[len(v) for v in quality_bins_f]}")
-    logger.debug(f"Reverse bin sizes {[len(v) for v in quality_bins_r]}")
+    quality_bins_f = modeller.divide_qualities_into_bins(qualities_forward)
+    quality_bins_r = modeller.divide_qualities_into_bins(qualities_reverse)
 
     # getting distribution of mean sequence quality
     mean_f = [len(quality_bin) for quality_bin in quality_bins_f]
     mean_r = [len(quality_bin) for quality_bin in quality_bins_r]
 
-    hists_f = modeller.quality_bins_to_histogram(quality_bins_f, min_bin_size)
-    hists_r = modeller.quality_bins_to_histogram(quality_bins_r, min_bin_size)
+    hists_f = modeller.quality_bins_to_histogram(quality_bins_f)
+    hists_r = modeller.quality_bins_to_histogram(quality_bins_r)
 
     # modern illumina instruments return reads of the same length
     # in case our bam file contains aligned reads of different length,
@@ -211,9 +200,6 @@ def to_model(bam_path, output, min_read_length, n_bins, sample_size):
     length_forward = min((len(x) for x in hists_f if len(x) > 1))
     length_reverse = min((len(x) for x in hists_r if len(x) > 1))
     read_length = min(length_forward, length_reverse)
-
-    hists_f = [hist if len(hist) != 0 else read_length*[41*[0]] for hist in hists_f]
-    hists_r = [hist if len(hist) != 0 else read_length*[41*[0]] for hist in hists_r]
 
     # now we can resize the substitution and indel matrices before
     # doing operations on them

--- a/iss/bam.py
+++ b/iss/bam.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from iss import util
 from iss import modeller
 
-from scipy import stats
 from random import random
 
 import sys

--- a/iss/error_models/__init__.py
+++ b/iss/error_models/__init__.py
@@ -136,7 +136,7 @@ class ErrorModel(object):
                     mut_seq.append(nucl_to_add)
             elif orientation == 'reverse':
                 for i in range(to_add):
-                    if read_start-1 - i < 0:
+                    if read_start - 1 - i < 0:
                         nucl_to_add = 'A'
                     else:
                         nucl_to_add = util.rev_comp(

--- a/iss/error_models/basic.py
+++ b/iss/error_models/basic.py
@@ -4,10 +4,6 @@
 from iss import util
 from iss.error_models import ErrorModel
 
-from Bio.Seq import MutableSeq
-from Bio.SeqRecord import SeqRecord
-
-import random
 import numpy as np
 
 

--- a/iss/error_models/kde.py
+++ b/iss/error_models/kde.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from iss import util
 from iss.error_models import ErrorModel
 
-from Bio.Seq import MutableSeq
-from Bio.SeqRecord import SeqRecord
-from scipy import stats
-
-import sys
-import random
 import numpy as np
 
 

--- a/iss/error_models/kde.py
+++ b/iss/error_models/kde.py
@@ -66,10 +66,13 @@ class KDErrorModel(ErrorModel):
             mean = self.mean_reverse
 
         norm_mean = mean / sum(mean)
-
-        # Pick a bin by probability based on the size of the bins
+        # quality_bin = np.searchsorted(norm_mean, np.random.rand())
         quality_bin = np.random.choice(range(len(norm_mean)), p=norm_mean)
-
+        # downgrades index out of bound (ex rand is 1, last bin in searchsorted
+        # is 0.95) to best quality bin
+        if quality_bin == 4:
+            quality_bin = 3
+            
         cdfs_bin = cdfs[quality_bin]
 
         phred_list = []

--- a/iss/error_models/kde.py
+++ b/iss/error_models/kde.py
@@ -66,13 +66,10 @@ class KDErrorModel(ErrorModel):
             mean = self.mean_reverse
 
         norm_mean = mean / sum(mean)
-        # quality_bin = np.searchsorted(norm_mean, np.random.rand())
+
+        # Pick a bin by probability based on the size of the bins
         quality_bin = np.random.choice(range(len(norm_mean)), p=norm_mean)
-        # downgrades index out of bound (ex rand is 1, last bin in searchsorted
-        # is 0.95) to best quality bin
-        if quality_bin == 4:
-            quality_bin = 3
-            
+
         cdfs_bin = cdfs[quality_bin]
 
         phred_list = []

--- a/iss/error_models/perfect.py
+++ b/iss/error_models/perfect.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from iss import util
 from iss.error_models import ErrorModel
 
 

--- a/iss/generator.py
+++ b/iss/generator.py
@@ -153,12 +153,14 @@ def simulate_read(record, ErrorModel, i, cpu_number, sequence_type):
     # assign start position reverse read
     # if sequence_type == metagenomics, get a start position based on insert_size
     # if sequence_type == amplicon, start position is the end of the read
-    if sequence_type == 'metagenomics':
+    if sequence_type == "metagenomics":
         reverse_start = forward_end + insert_size
         reverse_end = reverse_start + read_length
-    elif sequence_type == 'amplicon':
+    elif sequence_type == "amplicon":
         reverse_start = len(record.seq) - read_length
-        reverse_end = reverse_start + read_length - 1
+        reverse_end = reverse_start + read_length
+    else:
+        raise ValueError(f"Sequence type {sequence_type} not known")    
     if reverse_end > len(record.seq):
         # we use random insert when the modelled template length distribution
         # is too large

--- a/iss/generator.py
+++ b/iss/generator.py
@@ -123,6 +123,8 @@ def simulate_read(record, ErrorModel, i, cpu_number, sequence_type):
                 0, len(record.seq) - (2 * read_length + insert_size))
         elif sequence_type == 'amplicon':
             forward_start = 0
+        else:
+            raise RuntimeError(f"sequence type '{sequence_type}' is not supported")
     except AssertionError as e:
         raise
     except ValueError as e:
@@ -131,7 +133,6 @@ def simulate_read(record, ErrorModel, i, cpu_number, sequence_type):
             % (record.id, e))
         forward_start = max(0, random.randrange(
             0, len(record.seq) - read_length))
-        # raise
 
     forward_end = forward_start + read_length
     bounds = (forward_start, forward_end)
@@ -158,7 +159,7 @@ def simulate_read(record, ErrorModel, i, cpu_number, sequence_type):
         reverse_start = len(record.seq) - read_length
         reverse_end = reverse_start + read_length
     else:
-        raise ValueError(f"Sequence type {sequence_type} not known")    
+        raise ValueError(f"Sequence type {sequence_type} not known")
     if reverse_end > len(record.seq):
         # we use random insert when the modelled template length distribution
         # is too large

--- a/iss/generator.py
+++ b/iss/generator.py
@@ -7,9 +7,7 @@ from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqUtils import GC
 from Bio.SeqRecord import SeqRecord
-from shutil import copyfileobj
 
-import os
 import sys
 import random
 import logging

--- a/iss/generator.py
+++ b/iss/generator.py
@@ -113,7 +113,7 @@ def simulate_read(record, ErrorModel, i, cpu_number, sequence_type):
 
     read_length = ErrorModel.read_length
     insert_size = ErrorModel.random_insert_size()
-    print(sequence_type)
+
     # generate the forward read
     try:  # a ref sequence has to be longer than 2 * read_length + i_size
         assert read_length < len(record.seq)

--- a/iss/modeller.py
+++ b/iss/modeller.py
@@ -3,7 +3,6 @@
 
 from iss import util
 from scipy import stats
-from joblib import Parallel, delayed
 
 import logging
 import numpy as np

--- a/iss/modeller.py
+++ b/iss/modeller.py
@@ -24,14 +24,14 @@ def insert_size(insert_size_distribution):
         bw_method=0.2 / np.std(insert_size_distribution, ddof=1))
     x_grid = np.linspace(
         min(insert_size_distribution),
-        max(insert_size_distribution), 1000)
+        max(insert_size_distribution), 1000)  #TODO: Do we not need te use these min and max again when generating insertsizes from this cdf????
     kde = kde.evaluate(x_grid)
     cdf = np.cumsum(kde)
     cdf = cdf / cdf[-1]
     return cdf
 
 
-def divide_qualities_into_bins(qualities, n_bins=4):
+def divide_qualities_into_bins(qualities, n_bins):
     """Divides the raw quality scores in bins according to the mean phred
     quality of the sequence they come from
 
@@ -49,16 +49,15 @@ def divide_qualities_into_bins(qualities, n_bins=4):
     ranges = np.split(np.array(range(40)), n_bins)
     for quality in qualities:
         mean = int(quality[0][1])  # mean is at 1 and same regardless of b pos
-        which_array = 0
-        for array in ranges:
+        for i, array in enumerate(ranges):
             if mean in array:
-                read = np.fromiter((q[0] for q in quality), dtype=np.float)
-                bin_lists[which_array].append(read)
-            which_array += 1
+                read = np.fromiter((q[0] for q in quality), dtype=float)
+                bin_lists[i].append(read)
+                break
     return bin_lists
 
 
-def quality_bins_to_histogram(bin_lists):
+def quality_bins_to_histogram(bin_lists, min_bin_size):
     """Wrapper function to generate cdfs for each quality bins
 
     Generate cumulative distribution functions for a number of mean quality
@@ -73,9 +72,8 @@ def quality_bins_to_histogram(bin_lists):
     """
     logger = logging.getLogger(__name__)
     cdf_bins = []
-    i = 0
-    for qual_bin in bin_lists:
-        if len(qual_bin) > 1:
+    for i, qual_bin in enumerate(bin_lists):
+        if len(qual_bin) > min_bin_size:
             logger.debug('Transposing matrix for mean cluster #%s' % i)
             # quals = np.asarray(qual_bin).T  # seems to make clunkier models
             quals = [q for q in zip(*qual_bin)]
@@ -84,9 +82,8 @@ def quality_bins_to_histogram(bin_lists):
             cdfs_list = raw_qualities_to_histogram(quals)
             cdf_bins.append(cdfs_list)
         else:
-            logger.debug('Mean quality bin #%s of length < 1. Skipping' % i)
+            logger.info(f'Mean quality bin #{i} of length < {min_bin_size}. Skipping')
             cdf_bins.append([])
-        i += 1
     return cdf_bins
 
 
@@ -109,15 +106,14 @@ def raw_qualities_to_histogram(qualities):
     # quals = util.split_list([i for i in zip(*qualities)], n_parts=cpus)
     cdfs_list = []
     for q in qualities:
-        numpy_log_handler = np.seterrcall(util.nplog)
         with np.errstate(under='ignore', divide='call'):
             try:
                 kde = stats.gaussian_kde(q, bw_method=0.2 / np.std(q, ddof=1))
-            except np.linalg.linalg.LinAlgError as e:
+            except Exception as e:
                 # if np.std of array is 0, we modify the array slightly to be
                 # able to divide by ~ np.std
                 # this will print a FloatingPointError in DEBUG mode
-                # logger.debug('np.std of quality array is zero: %s' % e)
+                logger.debug('np.std of quality array is zero: %s' % e)
                 q = list(q)
                 q[-1] += 1
                 kde = stats.gaussian_kde(q, bw_method=0.2 / np.std(q, ddof=1))
@@ -226,7 +222,7 @@ def subst_matrix_to_choices(substitution_matrix, read_length):
                     [count / sums['A'] for
                         count in substitution_matrix[pos][1:4]])
             except FloatingPointError as e:
-                logger.debug(e, exc_info=True)
+                # logger.debug(e, exc_info=True)
                 A = (['T', 'C', 'G'], [1/3, 1/3, 1/3])
             try:
                 T = (
@@ -234,7 +230,7 @@ def subst_matrix_to_choices(substitution_matrix, read_length):
                     [count / sums['T'] for
                         count in substitution_matrix[pos][5:8]])
             except FloatingPointError as e:
-                logger.debug(e, exc_info=True)
+                # logger.debug(e, exc_info=True)
                 T = (['A', 'C', 'G'], [1/3, 1/3, 1/3])
             try:
                 C = (
@@ -242,7 +238,7 @@ def subst_matrix_to_choices(substitution_matrix, read_length):
                     [count / sums['C'] for
                         count in substitution_matrix[pos][9:12]])
             except FloatingPointError as e:
-                logger.debug(e, exc_info=True)
+                # logger.debug(e, exc_info=True)
                 C = (['A', 'T', 'G'], [1/3, 1/3, 1/3])
             try:
                 G = (
@@ -250,7 +246,7 @@ def subst_matrix_to_choices(substitution_matrix, read_length):
                     [count / sums['G'] for
                         count in substitution_matrix[pos][13:]])
             except FloatingPointError as e:
-                logger.debug(e, exc_info=True)
+                # logger.debug(e, exc_info=True)
                 G = (['A', 'T', 'C'], [1/3, 1/3, 1/3])
 
             nucl_choices['A'] = A

--- a/iss/test/test_abundance.py
+++ b/iss/test/test_abundance.py
@@ -3,7 +3,7 @@
 
 from iss import util
 from iss import abundance
-from nose.tools import raises, assert_almost_equal, with_setup
+from nose.tools import raises, with_setup
 
 import numpy as np
 

--- a/iss/test/test_download.py
+++ b/iss/test/test_download.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-
 from iss import download
 from iss.util import cleanup
 

--- a/iss/test/test_error_model.py
+++ b/iss/test/test_error_model.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from pickle import UnpicklingError
-from iss.error_models import ErrorModel, basic, kde, perfect
-from iss.util import load, rev_comp
+from iss.error_models import basic, kde, perfect
+from iss.util import rev_comp
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord

--- a/iss/test/test_error_model.py
+++ b/iss/test/test_error_model.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from pickle import UnpicklingError
 from iss.error_models import ErrorModel, basic, kde, perfect
 from iss.util import load, rev_comp
 
@@ -141,6 +142,6 @@ def test_introduce_indels_rev():
     assert len(read.seq) == 20
     assert read.seq == 'CGTACGGTACGGTACGGTAC'
 
-@raises(SystemExit)
+@raises(SystemExit, UnpicklingError)
 def test_bad_err_mod():
     err_mod = kde.KDErrorModel('data/empty_file')

--- a/iss/test/test_generator.py
+++ b/iss/test/test_generator.py
@@ -5,14 +5,14 @@ from __future__ import unicode_literals
 
 from iss import generator
 from iss.util import cleanup
-from iss.error_models import ErrorModel, basic, kde
+from iss.error_models import basic, kde
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from nose.tools import with_setup, raises
 
-import os
 import sys
+import os
 import random
 import numpy as np
 
@@ -110,3 +110,35 @@ def test_kde_short():
         read_tuple = generator.simulate_read(ref_genome, err_mod, 1, 0, 'metagenomics')
         big_read = ''.join(str(read_tuple[0].seq) + str(read_tuple[1].seq))
         assert big_read == 'ACCAAACCAAACCAAACCAAGGTTTGGTTTGGTTTGGTGT'
+
+
+def test_amp():
+    if sys.version_info > (3,):
+        random.seed(42)
+        np.random.seed(42)
+        err_mod = kde.KDErrorModel(
+            os.path.join(
+                os.path.dirname(__file__),
+                '../profiles/MiSeq'
+            )
+        )
+        print(err_mod.read_length)
+        ref_genome = SeqRecord(
+            Seq((
+                "TTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGG"
+                "CCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATTT"
+                )),
+            id='my_amplicon',
+            description='test amplicon'
+        )
+        read_tuple = generator.simulate_read(ref_genome, err_mod, 1, 0, 'amplicon')
+        assert len(read_tuple[0].seq) == 301
+        assert read_tuple[0].seq.startswith("TTTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        assert len(read_tuple[1].seq) == 301
+        assert read_tuple[1].seq.startswith("AAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT")

--- a/iss/test/test_modeller.py
+++ b/iss/test/test_modeller.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from builtins import next
-
 from iss import bam
 from iss import modeller
 

--- a/iss/test/test_util.py
+++ b/iss/test/test_util.py
@@ -148,7 +148,6 @@ def test_concatenate():
         assert len(f.readlines()) == 40
 
 
-@raises(SystemExit)
 def test_concatenate_read_only():
     genome_files = ['data/ecoli.fasta'] * 2
     util.concatenate(genome_files, 'data/read_only.fasta')

--- a/iss/test/test_util.py
+++ b/iss/test/test_util.py
@@ -7,9 +7,6 @@ from iss import util
 
 from Bio import SeqIO
 
-import random
-
-
 def setup_function():
     output_file_prefix = 'data/.test'
 


### PR DESCRIPTION
Hi! 
This is Thijs from ENPICOM. We talked some weeks ago about including support for amplicon sequencing in ISS. We have developed and tested this functionality and would like your opinion on the changes proposed here.

This PR includes the following:
- A new argument `--sequence_type` which adds the 'amplicon' option to the default 'metagenomics' 
  - This changes the `read_start` and `read_end` logic, for amplicon sequences the read pair is generated from the actual start and end of the sequence.
- Cleaned up some unused imports, variables, parameters, etc...
- Added new tests for amplicon sequencing mode