### PR TITLE
Remove Unused Dependency: Future

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-future = "*"
 numpy = "*"
 scipy = "*"
 biopython = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -197,13 +197,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.0.0"
         },
-        "future": {
-            "hashes": [
-                "sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"
-            ],
-            "index": "pypi",
-            "version": "==0.18.3"
-        },
         "idna": {
             "hashes": [
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
 
     tests_require=['nose'],
     install_requires=['numpy', 'scipy', 'biopython>=1.79',
-                      'pysam>=0.15.1','joblib',
+                      'pysam>=0.15.1', 'joblib',
                       'requests'],
     include_package_data=True,
 

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
 
     tests_require=['nose'],
     install_requires=['numpy', 'scipy', 'biopython>=1.79',
-                      'pysam>=0.15.1', 'future',
-                      'joblib', 'requests'],
+                      'pysam>=0.15.1','joblib',
+                      'requests'],
     include_package_data=True,
 
     entry_points={


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `future` from the `setup.py`,  `Pipfile` and  `Pipfile.lock`configuration files. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `future` library was originally introduced to the project to bridge compatibility between Python 2 and Python 3, as per b9f6035. However, as evident from ed6a204, the project decided to drop support for Python 2, rendering the `future`  library superfluous. Despite this change in the codebase, `future` continued to be listed in the project's dependency files. Removing this unused dependency  reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.

## Changes

- Removed the future dependency from `pipfile.lock`.
- Removed the future dependency from `setup.py`.
- Removed the future dependency from `pipfile`.

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.
